### PR TITLE
Investigate division by zero in genericdatahandler

### DIFF
--- a/cosinorage/features/utils/nonparam_analysis.py
+++ b/cosinorage/features/utils/nonparam_analysis.py
@@ -388,6 +388,15 @@ def RA(m10: List[float], l5: List[float]) -> List[float]:
     if len(m10) != len(l5):
         raise ValueError("m10 and l5 must have the same length")
 
-    ra = [(m10[i] - l5[i]) / (m10[i] + l5[i]) for i in range(len(m10))]
+    # Safe computation to avoid division by zero; return NaN for undefined RA
+    ra: List[float] = []
+    for i in range(len(m10)):
+        numerator = m10[i] - l5[i]
+        denominator = m10[i] + l5[i]
+
+        if pd.isna(numerator) or pd.isna(denominator) or np.isclose(denominator, 0.0):
+            ra.append(np.nan)
+        else:
+            ra.append(numerator / denominator)
 
     return ra


### PR DESCRIPTION
Add a safe check to the RA calculation to prevent float division by zero errors.

The `RA` (Relative Amplitude) calculation `(M10 - L5) / (M10 + L5)` previously raised a `ZeroDivisionError` when `M10 + L5` was zero, particularly with low/zero activity data. While `BulkWearableFeatures` suppressed this error, direct calls to `WearableFeatures` would crash. This change returns `NaN` for undefined `RA` values instead of crashing.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5813f40-b12e-4d4a-bb5c-8d6d0e79ffee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b5813f40-b12e-4d4a-bb5c-8d6d0e79ffee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

