### PR TITLE
Fix Read the Docs build by mocking heavy dependencies.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,11 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
+    python: "3.11"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
@@ -30,3 +26,5 @@ sphinx:
 python:
   install:
     - requirements: docs/source/requirements.txt
+    - method: pip
+      path: .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ if os.environ.get("READTHEDOCS", "") == "True":
 project = 'CosinorAge'
 copyright = '2025, Jacob Leo Oskar Hunecke'
 author = 'Jacob Leo Oskar Hunecke'
-release = '1.0.5'
+release = '1.0.7'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -39,6 +39,21 @@ extensions = [
 templates_path = ['_templates']
 exclude_patterns = []
 
+# Heavy runtime deps are mocked so docs build without claid/skdh/CosinorPy.
+autodoc_mock_imports = [
+    'claid',
+    'claid.data_collection',
+    'claid.data_collection.load',
+    'claid.data_collection.load.load_sensor_data',
+    'skdh',
+    'skdh.preprocessing',
+    'skdh.sleep',
+    'skdh.sleep.endpoints',
+    'skdh.sleep.sleep_classification',
+    'CosinorPy',
+    'CosinorPy.cosinor1',
+]
+
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -46,7 +61,7 @@ exclude_patterns = []
 
 html_theme = 'furo'
 html_static_path = ['_static']
-html_title = 'CosinorAge 1.0.5 Documentation'
+html_title = 'CosinorAge 1.0.7 Documentation'
 
 autosummary_generate = True
 

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,17 +1,13 @@
 sphinx
 furo
 sphinx-autodoc-typehints
-sphinx-rtd-theme
 pandas
-tqdm
 numpy
 matplotlib
 seaborn
 scipy
+tqdm
 scikit-learn
 statsmodels
-scikit-digital-health
-claid
-CosinorPy
 
 git+https://github.com/readthedocs/sphinx-build-compatibility#egg=sphinx-build-compatibility


### PR DESCRIPTION
Use Python 3.11, drop claid/skdh/CosinorPy from doc requirements, and mock them in Sphinx autodoc so RTD does not need gfortran.